### PR TITLE
FRONTEND-0480 :: Feature Internal :: Typescript ESLint + Prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 module.exports = {
-  printWidth: 120,
   tabWidth: 2,
-  singleQuote: true,
   trailingComma: 'all',
   bracketSameLine: true,
   // overrides: [


### PR DESCRIPTION
**Merge / Pull request information:**
Reseting printWidth to use the default value, 80.

Reseting singleQuotes to use the default value, a more intelligent version depending on the content.
https://prettier.io/docs/en/options.html#quotes